### PR TITLE
Fix click-to-edit by removing duplicate init

### DIFF
--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -340,17 +340,9 @@ Questions?  >>  Aheadflank.ai@gmail.com
     </main>
     <script src="./js/arena.js"></script>
     <script>
-        // --- Application Entry Point ---
-        document.addEventListener('DOMContentLoaded', () => {
-            new Simulator();
-        });
-    </script>
-    <script>
         window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
-</script>
-</script>
-<script>
+    <script>
     (function(){
         const content = document.getElementById('radar-wrapper');
         let isDragging = false;


### PR DESCRIPTION
## Summary
- remove extra `new Simulator()` call from `index.html`
- clean up stray closing `<script>` tags

## Testing
- `node --check Simulator/js/arena.js`


------
https://chatgpt.com/codex/tasks/task_e_68659ed901a48325a3512bfe15ecd63c