### PR TITLE
Fix angle clamping and update track header

### DIFF
--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -464,3 +464,8 @@ summary.collapsible-summary::before {
 details[open] > summary.collapsible-summary::before {
   transform: rotate(90deg);
 }
+
+/* Larger font for selected track ID */
+#track-id {
+    font-size: 28px;
+}

--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -304,7 +304,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                     </div>
                     <!-- Data Panels for selected track will be dynamically inserted here -->
                     <div class="data primary" id="track-data-container">
-                         <p class="font-bold tracking-wide data-title">TRACK <span id="track-id">--</span></p>
+                         <p class="font-bold tracking-wide data-title">Track <span id="track-id">--</span></p>
                         <div class="d-flex flex-column gap-1">
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Brg</span><span id="track-brg" class="data-value editable">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Rng</span><span id="track-rng" class="data-value editable">--</span></div>

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -615,7 +615,7 @@ class Simulator {
                 track.bearing = Math.max(0, Math.min(359.9, value));
                 didUpdate = true;
             } else if (id === 'track-rng') {
-                track.range = value;
+                track.range = Math.max(0, Math.min(359.9, value));
                 didUpdate = true;
             } else if (id === 'track-crs') {
                 track.course = Math.max(0, Math.min(359.9, value));
@@ -662,7 +662,7 @@ class Simulator {
     calculateAllData(track) {
         const dx = track.x - this.ownShip.x;
         const dy = track.y - this.ownShip.y;
-        track.range = Math.sqrt(dx**2 + dy**2);
+        track.range = Math.max(0, Math.min(359.9, Math.sqrt(dx**2 + dy**2)));
         track.bearing = (this.toDegrees(Math.atan2(dx, dy)) + 360) % 360;
 
         const ownShipCanvasAngle = this.toRadians(this.bearingToCanvasAngle(this.ownShip.course));


### PR DESCRIPTION
## Summary
- limit track range to the same 0-359.9 range used for bearings and course
- keep range clamped during data calculations
- capitalize track header as "Track" and enlarge the ID text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865b15ba82c8325b5a31391abbcab8d