### PR TITLE
Add track controls under simulation panel

### DIFF
--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -134,14 +134,6 @@ main {
     border-top:1px solid #333;
     font-size: 1.35rem;
 }
-#trk-controls {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0;
-    border-top:1px solid #333;
-    font-size: 1.35rem;
-}
 #sim-clock {
     font-size: 1.8rem;
     padding-bottom: 17px;
@@ -163,11 +155,7 @@ main {
 }
 
 #btn-scen {
-    padding: 10px 0;
-    flex: 0 0 50%;
-}
-#btn-rev, #btn-ff, #btn-drop-trk, #btn-add-trk {
-    flex: 0 0 25%;
+    padding: 10px 0
 }
 #btn-rev, #btn-ff {
     flex: 0 0 25%;
@@ -196,7 +184,7 @@ main {
 }
 .control-btn svg { width: 1em; height: 1em; }
 /* Instant tooltip styling using data-tooltip attribute */
-[data-tooltip]::after {
+.control-btn[data-tooltip]::after {
     content: attr(data-tooltip);
     position: absolute;
     top: 10%;
@@ -214,7 +202,7 @@ main {
     opacity: 0;
     transition: opacity 0.1s ease-in-out;
 }
-[data-tooltip]:hover::after {
+.control-btn[data-tooltip]:hover::after {
     opacity: 1;
 }
 .control-btn.unselected {
@@ -310,6 +298,11 @@ main {
     outline: none;
 }
 #data-pane .mt-2 { margin-top: 0.25rem !important; }
+#btn-add-track,
+#btn-drop-track {
+    font-size: 32px;
+    line-height: 1;
+}
 
 /* Let the radar fill the middle, and center its contents
 #radar {
@@ -370,6 +363,19 @@ main {
     z-index: 1000;
     line-height: 1.4;
     white-space: pre; /* To respect newlines and spacing */
+}
+#tooltip {
+    position: fixed;
+    display: none;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: var(--radar-green);
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    border-radius: 0.25rem;
+    pointer-events: none;
+    z-index: 1000;
+    line-height: 1.4;
+    white-space: nowrap;
 }
 #logo, #logo span {
     font-family: 'Share Tech Mono', monospace;
@@ -475,4 +481,5 @@ details[open] > summary.collapsible-summary::before {
 /* Larger font for selected track ID */
 #track-id {
     font-size: 22px;
+}
 }

--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -134,6 +134,14 @@ main {
     border-top:1px solid #333;
     font-size: 1.35rem;
 }
+#trk-controls {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    border-top:1px solid #333;
+    font-size: 1.35rem;
+}
 #sim-clock {
     font-size: 1.8rem;
     padding-bottom: 17px;
@@ -155,7 +163,11 @@ main {
 }
 
 #btn-scen {
-    padding: 10px 0
+    padding: 10px 0;
+    flex: 0 0 50%;
+}
+#btn-rev, #btn-ff, #btn-drop-trk, #btn-add-trk {
+    flex: 0 0 25%;
 }
 #btn-rev, #btn-ff {
     flex: 0 0 25%;
@@ -184,7 +196,7 @@ main {
 }
 .control-btn svg { width: 1em; height: 1em; }
 /* Instant tooltip styling using data-tooltip attribute */
-.control-btn[data-tooltip]::after {
+[data-tooltip]::after {
     content: attr(data-tooltip);
     position: absolute;
     top: 10%;
@@ -202,7 +214,7 @@ main {
     opacity: 0;
     transition: opacity 0.1s ease-in-out;
 }
-.control-btn[data-tooltip]:hover::after {
+[data-tooltip]:hover::after {
     opacity: 1;
 }
 .control-btn.unselected {
@@ -298,11 +310,6 @@ main {
     outline: none;
 }
 #data-pane .mt-2 { margin-top: 0.25rem !important; }
-#btn-add-track,
-#btn-drop-track {
-    font-size: 32px;
-    line-height: 1;
-}
 
 /* Let the radar fill the middle, and center its contents
 #radar {

--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -40,6 +40,7 @@
 <body>
 
 <div id="drag-tooltip"></div>
+<div id="tooltip"></div>
 
 <div id="mobile-blocker" class="mobile-blocker">
   Maneuver is currently not compatible with cell-phone browsers. <br> <br>
@@ -234,7 +235,10 @@ Questions?  >>  Aheadflank.ai@gmail.com
                 <span>Beta</span>
             </section>
             <nav id="button-bar" class="d-flex flex-column align-items-bottom gap-2 justify-content-end">
-                <!-- Scenario and Range Controls -->
+                <!-- Add/Drop Track and Scenario Buttons -->
+                <button id="btn-add-track" class="control-btn selected p-2" data-tooltip="Add New Track">+</button>
+                <button id="btn-drop-track" class="control-btn selected p-2" data-tooltip="Drop Selected Track">-</button>
+                <span class="w-100 border-top border-secondary"></span>
                 <!-- Button Group 1 -->
                 <!-- <button id="btn-wind" class="control-btn" data-tooltip="Toggle Wind Display">WIND</button>
                 <button id="btn-rmv" class="control-btn" data-tooltip="Toggle Relative Motion Vectors">RM V</button>
@@ -245,7 +249,9 @@ Questions?  >>  Aheadflank.ai@gmail.com
                 <span class="w-100 border-top border-secondary"></span>
                 <!-- Button Group 3 -->
                 <button id="btn-range" class="control-btn selected" data-tooltip="Toggle Radar Range (3, 6, 12, 24 nm)">12.0</button>
-
+                <!-- Help Button -->
+                <span class="w-100 border-top border-secondary"></span>
+                <button id="btn-help" class="control-btn unselected p-2" data-tooltip="Show Instructions">HELP</button>
 
             </nav>
         </section>
@@ -282,15 +288,12 @@ Questions?  >>  Aheadflank.ai@gmail.com
                         </button>
                     </div>
                 </section>
-                <div id="trk-controls">
-                    <button id="btn-drop-trk" class="sim-control-btn unselected" data-tooltip="Drop Selected Track">- trk</button>
+                <!-- New Scenario Button -->
                     <button id="btn-scen" class="sim-control-btn selected" data-tooltip="Generate New Scenario">
                         <svg xmlns="http://www.w3.org/2000/svg" style="width:1em;height:1em;margin:auto;" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/>
-                        </svg> New scene
+                        </svg> New scenario
                     </button>
-                    <button id="btn-add-trk" class="sim-control-btn unselected" data-tooltip="Add New Track">+ trk</button>
-                </div>
                 <div id="data-pane" class="d-flex flex-column" >
                     <!-- OwnShip Data -->
                     <div class="data primary" id="ownship-data-container">
@@ -311,7 +314,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                         </div>
                     </div>
                     <details class="data secondary collapsible-panel" id="cpa-data-container">
-                        <summary class="collapsible-summary" data-tooltip="Toggle CPA Data">CPA</summary>
+                        <summary class="collapsible-summary" data-tooltip="Reveal CPA Data & Show Radar Symbols">CPA</summary>
                         <div class="d-flex flex-column gap-1">
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Brg</span><span id="cpa-brg" class="data-value text-end">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Rng</span><span id="cpa-rng" class="data-value text-end">--</span></div>
@@ -327,7 +330,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                         </div>
                     </div> -->
                     <details class="data secondary collapsible-panel" id="rm-data-container">
-                        <summary class="collapsible-summary" data-tooltip="Toggle Relative Motion">Rel Motion</summary>
+                        <summary class="collapsible-summary" data-tooltip="Reveal RM Data & Show Radar Symbols">Rel Motion</summary>
                         <div class="d-flex flex-column gap-1">
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Direction RM</span><span id="rm-dir" class="data-value text-end">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Spd RM</span><span id="rm-spd" class="data-value text-end">--</span></div>
@@ -347,7 +350,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                         </div>
                     </div> -->
                     <details class="data secondary collapsible-panel" id="wind-data-container">
-                        <summary class="collapsible-summary" data-tooltip="Toggle Wind Data">Wind</summary>
+                        <summary class="collapsible-summary" data-tooltip="Reveal Wind Data & Show Radar Symbols">Wind</summary>
                         <div class="d-flex flex-column gap-1">
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">True</span><span id="wind-true" class="data-value text-end">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Rel</span><span id="wind-rel" class="data-value text-end">--</span></div>

--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -234,10 +234,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                 <span>Beta</span>
             </section>
             <nav id="button-bar" class="d-flex flex-column align-items-bottom gap-2 justify-content-end">
-                <!-- Add/Drop Track and Scenario Buttons -->
-                <button id="btn-add-track" class="control-btn selected p-2" data-tooltip="Add New Track">+</button>
-                <button id="btn-drop-track" class="control-btn selected p-2" data-tooltip="Drop Selected Track">-</button>
-                <span class="w-100 border-top border-secondary"></span>
+                <!-- Scenario and Range Controls -->
                 <!-- Button Group 1 -->
                 <!-- <button id="btn-wind" class="control-btn" data-tooltip="Toggle Wind Display">WIND</button>
                 <button id="btn-rmv" class="control-btn" data-tooltip="Toggle Relative Motion Vectors">RM V</button>
@@ -248,9 +245,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                 <span class="w-100 border-top border-secondary"></span>
                 <!-- Button Group 3 -->
                 <button id="btn-range" class="control-btn selected" data-tooltip="Toggle Radar Range (3, 6, 12, 24 nm)">12.0</button>
-                <!-- Help Button -->
-                <span class="w-100 border-top border-secondary"></span>
-                <button id="btn-help" class="control-btn unselected p-2" data-tooltip="Show Instructions">HELP</button>
+
 
             </nav>
         </section>
@@ -287,33 +282,36 @@ Questions?  >>  Aheadflank.ai@gmail.com
                         </button>
                     </div>
                 </section>
-                <!-- New Scenario Button -->
+                <div id="trk-controls">
+                    <button id="btn-drop-trk" class="sim-control-btn unselected" data-tooltip="Drop Selected Track">- trk</button>
                     <button id="btn-scen" class="sim-control-btn selected" data-tooltip="Generate New Scenario">
                         <svg xmlns="http://www.w3.org/2000/svg" style="width:1em;height:1em;margin:auto;" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/>
                         </svg> New scene
                     </button>
+                    <button id="btn-add-trk" class="sim-control-btn unselected" data-tooltip="Add New Track">+ trk</button>
+                </div>
                 <div id="data-pane" class="d-flex flex-column" >
                     <!-- OwnShip Data -->
                     <div class="data primary" id="ownship-data-container">
                         <p class="font-bold tracking-wide data-title">OwnShip</p>
                         <div class="d-flex flex-column gap-1">
-                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Crs</span><span id="ownship-crs" class="data-value editable"></span></div>
-                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Spd</span><span id="ownship-spd" class="data-value editable"></span></div>
+                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Crs</span><span id="ownship-crs" class="data-value editable" data-tooltip="Edit Course"></span></div>
+                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Spd</span><span id="ownship-spd" class="data-value editable" data-tooltip="Edit Speed"></span></div>
                         </div>
                     </div>
                     <!-- Data Panels for selected track will be dynamically inserted here -->
                     <div class="data primary" id="track-data-container">
                          <p class="font-bold tracking-wide data-title">Track <span id="track-id">--</span></p>
                         <div class="d-flex flex-column gap-1">
-                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Brg</span><span id="track-brg" class="data-value editable">--</span></div>
-                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Rng</span><span id="track-rng" class="data-value editable">--</span></div>
-                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Crs</span><span id="track-crs" class="data-value editable">--</span></div>
-                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Spd</span><span id="track-spd" class="data-value editable">--</span></div>
+                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Brg</span><span id="track-brg" class="data-value editable" data-tooltip="Edit Bearing">--</span></div>
+                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Rng</span><span id="track-rng" class="data-value editable" data-tooltip="Edit Range">--</span></div>
+                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Crs</span><span id="track-crs" class="data-value editable" data-tooltip="Edit Course">--</span></div>
+                            <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Spd</span><span id="track-spd" class="data-value editable" data-tooltip="Edit Speed">--</span></div>
                         </div>
                     </div>
                     <details class="data secondary collapsible-panel" id="cpa-data-container">
-                        <summary class="collapsible-summary">CPA</summary>
+                        <summary class="collapsible-summary" data-tooltip="Toggle CPA Data">CPA</summary>
                         <div class="d-flex flex-column gap-1">
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Brg</span><span id="cpa-brg" class="data-value text-end">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Rng</span><span id="cpa-rng" class="data-value text-end">--</span></div>
@@ -329,7 +327,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                         </div>
                     </div> -->
                     <details class="data secondary collapsible-panel" id="rm-data-container">
-                        <summary class="collapsible-summary">Rel Motion</summary>
+                        <summary class="collapsible-summary" data-tooltip="Toggle Relative Motion">Rel Motion</summary>
                         <div class="d-flex flex-column gap-1">
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Direction RM</span><span id="rm-dir" class="data-value text-end">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Spd RM</span><span id="rm-spd" class="data-value text-end">--</span></div>
@@ -349,7 +347,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                         </div>
                     </div> -->
                     <details class="data secondary collapsible-panel" id="wind-data-container">
-                        <summary class="collapsible-summary">Wind</summary>
+                        <summary class="collapsible-summary" data-tooltip="Toggle Wind Data">Wind</summary>
                         <div class="d-flex flex-column gap-1">
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">True</span><span id="wind-true" class="data-value text-end">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Rel</span><span id="wind-rel" class="data-value text-end">--</span></div>

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -222,15 +222,14 @@ class Simulator {
         this.iconPlay = document.getElementById('icon-play');
         this.iconPause = document.getElementById('icon-pause');
         this.btnRange = document.getElementById('btn-range');
-        this.btnAddTrack = document.getElementById('btn-add-track');
-        this.btnDropTrack = document.getElementById('btn-drop-track');
+        this.btnAddTrk = document.getElementById('btn-add-trk');
+        this.btnDropTrk = document.getElementById('btn-drop-trk');
         // this.btnWind = document.getElementById('btn-wind');
         this.btnScen = document.getElementById('btn-scen');
         this.btnFf = document.getElementById('btn-ff');
         this.btnRev = document.getElementById('btn-rev');
         this.ffSpeedIndicator = document.getElementById('ff-speed-indicator');
         this.revSpeedIndicator = document.getElementById('rev-speed-indicator');
-        this.btnHelp = document.getElementById('btn-help');
         this.helpModal = document.getElementById('help-modal');
         this.helpCloseBtn = document.getElementById('help-close-btn');
         this.helpContent = this.helpModal.querySelector('pre');
@@ -416,12 +415,11 @@ class Simulator {
         this.btnPlayPause.addEventListener('click', () => this.togglePlayPause());
         this.btnFf.addEventListener('click', () => this.fastForward());
         this.btnRev.addEventListener('click', () => this.rewind());
-        this.btnAddTrack.addEventListener('click', () => this.addTrack());
-        this.btnDropTrack.addEventListener('click', () => this.dropTrack());
+        this.btnAddTrk?.addEventListener('click', () => this.addTrack());
+        this.btnDropTrk?.addEventListener('click', () => this.dropTrack());
         this.btnScen.addEventListener('click', () => this.setupRandomScenario());
 
         // Help Modal
-        this.btnHelp.addEventListener('click', () => this.showHelpModal());
         this.helpCloseBtn.addEventListener('click', () => this.hideHelpModal());
         new ResizeObserver(() => {
             const scale = Math.max(0.8, Math.min(1.2, this.helpModal.clientWidth / 500));
@@ -1362,7 +1360,9 @@ class Simulator {
         this.simulationSpeed = 1;
         this.updateButtonStyles();
         this.updateSpeedIndicator();
-        this.startGameLoop();
+        if (this.isSimulationRunning) {
+            this.startGameLoop();
+        }
     }
 
     fastForward() {

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -222,14 +222,16 @@ class Simulator {
         this.iconPlay = document.getElementById('icon-play');
         this.iconPause = document.getElementById('icon-pause');
         this.btnRange = document.getElementById('btn-range');
-        this.btnAddTrk = document.getElementById('btn-add-trk');
-        this.btnDropTrk = document.getElementById('btn-drop-trk');
+        this.btnAddTrack = document.getElementById('btn-add-track');
+        this.btnDropTrack = document.getElementById('btn-drop-track');
         // this.btnWind = document.getElementById('btn-wind');
         this.btnScen = document.getElementById('btn-scen');
         this.btnFf = document.getElementById('btn-ff');
         this.btnRev = document.getElementById('btn-rev');
         this.ffSpeedIndicator = document.getElementById('ff-speed-indicator');
+        this.tooltip = document.getElementById("tooltip");
         this.revSpeedIndicator = document.getElementById('rev-speed-indicator');
+        this.btnHelp = document.getElementById('btn-help');
         this.helpModal = document.getElementById('help-modal');
         this.helpCloseBtn = document.getElementById('help-close-btn');
         this.helpContent = this.helpModal.querySelector('pre');
@@ -415,11 +417,12 @@ class Simulator {
         this.btnPlayPause.addEventListener('click', () => this.togglePlayPause());
         this.btnFf.addEventListener('click', () => this.fastForward());
         this.btnRev.addEventListener('click', () => this.rewind());
-        this.btnAddTrk?.addEventListener('click', () => this.addTrack());
-        this.btnDropTrk?.addEventListener('click', () => this.dropTrack());
+        this.btnAddTrack.addEventListener('click', () => this.addTrack());
+        this.btnDropTrack.addEventListener('click', () => this.dropTrack());
         this.btnScen.addEventListener('click', () => this.setupRandomScenario());
 
         // Help Modal
+        this.btnHelp.addEventListener('click', () => this.showHelpModal());
         this.helpCloseBtn.addEventListener('click', () => this.hideHelpModal());
         new ResizeObserver(() => {
             const scale = Math.max(0.8, Math.min(1.2, this.helpModal.clientWidth / 500));
@@ -445,6 +448,24 @@ class Simulator {
             this._scheduleUIUpdate();
         });
 
+        document.addEventListener("pointerover", e => {
+            const target = e.target.closest("[data-tooltip]");
+            if (target) {
+                this.tooltip.textContent = target.getAttribute("data-tooltip");
+                this.tooltip.style.display = "block";
+                this.tooltip.style.transform = `translate(${e.clientX - this.tooltip.offsetWidth - 10}px, ${e.clientY - this.tooltip.offsetHeight - 10}px)`;
+            }
+        });
+        document.addEventListener("pointermove", e => {
+            if (this.tooltip.style.display === "block") {
+                this.tooltip.style.transform = `translate(${e.clientX - this.tooltip.offsetWidth - 10}px, ${e.clientY - this.tooltip.offsetHeight - 10}px)`;
+            }
+        });
+        document.addEventListener("pointerout", e => {
+            if (!e.relatedTarget || !e.relatedTarget.closest("[data-tooltip]")) {
+                this.tooltip.style.display = "none";
+            }
+        });
         // Editable fields
         this.dataPane.addEventListener('click', (e) => {
             if (e.target.classList.contains('editable')) {
@@ -1364,11 +1385,6 @@ class Simulator {
             this.startGameLoop();
         }
     }
-
-    fastForward() {
-        const cycle = [1, ...this.ffSpeeds];
-        if (!this.isSimulationRunning || this.simulationSpeed < 0) {
-            this.simulationSpeed = this.ffSpeeds[0];
             this.isSimulationRunning = true;
         } else {
             let idx = cycle.indexOf(this.simulationSpeed);


### PR DESCRIPTION
## Summary
- remove add/drop/help buttons from side menu
- add new `- trk` and `+ trk` controls around "New scene"
- generalize tooltip styling and add tooltips for data pane values
- wire up new buttons and fix play/pause toggle logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865b6f8b02483259c532ffe0183234d