### PR TITLE
Update tooltips for data panels

### DIFF
--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -294,7 +294,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                         </div>
                     </div>
                     <details class="data secondary collapsible-panel" id="cpa-data-container">
-                        <summary class="collapsible-summary" data-tooltip="Reveal/Hide CPA Data &amp"\n "Show Radar Symbols">CPA</summary>
+                        <summary class="collapsible-summary" data-tooltip="Show/Hide CPA Data&#10;&amp; Radar Elements">CPA</summary>
                         <div class="d-flex flex-column gap-1">
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Brg</span><span id="cpa-brg" class="data-value text-end">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Rng</span><span id="cpa-rng" class="data-value text-end">--</span></div>
@@ -310,7 +310,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                         </div>
                     </div> -->
                     <details class="data secondary collapsible-panel" id="rm-data-container">
-                        <summary class="collapsible-summary" data-tooltip="Reveal/Hide RM Data &amp"\n "Show Radar Symbols">Rel Motion</summary>
+                        <summary class="collapsible-summary" data-tooltip="Show/Hide RM Data&#10;&amp; Radar Elements">Rel Motion</summary>
                         <div class="d-flex flex-column gap-1">
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Direction RM</span><span id="rm-dir" class="data-value text-end">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Spd RM</span><span id="rm-spd" class="data-value text-end">--</span></div>
@@ -330,7 +330,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                         </div>
                     </div> -->
                     <details class="data secondary collapsible-panel" id="wind-data-container">
-                        <summary class="collapsible-summary" data-tooltip="Reveal/Hide Wind Data &amp" \n "Show Radar Symbols">Wind</summary>
+                        <summary class="collapsible-summary" data-tooltip="Show/Hide Wind Data&#10;&amp; Radar Elements">Wind</summary>
                         <div class="d-flex flex-column gap-1">
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">True</span><span id="wind-true" class="data-value text-end">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Rel</span><span id="wind-rel" class="data-value text-end">--</span></div>


### PR DESCRIPTION
## Summary
- fix tooltip text for CPA, RM, and Wind panels so the hint is on two lines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865c6679914832585a84fd99eb5a875