### PR TITLE
Add Add/Drop Track buttons

### DIFF
--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -467,5 +467,5 @@ details[open] > summary.collapsible-summary::before {
 
 /* Larger font for selected track ID */
 #track-id {
-    font-size: 16px;
+    font-size: 22px;
 }

--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -279,8 +279,22 @@ main {
 #data-pane .mt-2 { margin-top: 0.25rem !important; }
 #btn-add-track,
 #btn-drop-track {
-    font-size: 32px;
-    line-height: 1;
+    width: 20px;
+    height: 20px;
+    font-family: 'Share Tech Mono', monospace;
+    font-size: 18px;
+    color: var(--radar-faint-green);
+    background: transparent;
+    border: none;
+    line-height: 18px;
+    text-align: center;
+    user-select: none;
+}
+
+#btn-add-track:hover,
+#btn-drop-track:hover {
+    color: var(--radar-green);
+    cursor: pointer;
 }
 
 /* Let the radar fill the middle, and center its contents

--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -285,8 +285,14 @@ Questions?  >>  Aheadflank.ai@gmail.com
                     </div>
                     <!-- Data Panels for selected track will be dynamically inserted here -->
                     <div class="data primary" id="track-data-container">
-                         <p class="font-bold tracking-wide data-title">Track <span id="track-id">--</span></p>
-                        <div class="d-flex flex-column gap-1">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <p class="font-bold tracking-wide data-title mb-0">Track <span id="track-id">--</span></p>
+                            <div id="track-controls" class="d-flex flex-column ms-auto" style="gap:10px;">
+                                <button id="btn-add-track"  title="Add new track">+</button>
+                                <button id="btn-drop-track" title="Drop this track">&ndash;</button>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-column gap-1 mt-2">
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Brg</span><span id="track-brg" class="data-value editable">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Rng</span><span id="track-rng" class="data-value editable">--</span></div>
                             <div class="d-flex justify-content-between align-items-baseline"><span class="data-label">Crs</span><span id="track-crs" class="data-value editable">--</span></div>

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -222,8 +222,8 @@ class Simulator {
         this.iconPlay = document.getElementById('icon-play');
         this.iconPause = document.getElementById('icon-pause');
         // this.btnRange = document.getElementById('btn-range');
-        // this.btnAddTrack = document.getElementById('btn-add-track');
-        // this.btnDropTrack = document.getElementById('btn-drop-track');
+        this.btnAddTrack  = document.getElementById('btn-add-track');
+        this.btnDropTrack = document.getElementById('btn-drop-track');
         // this.btnWind = document.getElementById('btn-wind');
         this.btnScen = document.getElementById('btn-scen');
         this.btnFf = document.getElementById('btn-ff');
@@ -416,8 +416,8 @@ class Simulator {
         this.btnPlayPause.addEventListener('click', () => this.togglePlayPause());
         this.btnFf.addEventListener('click', () => this.fastForward());
         this.btnRev.addEventListener('click', () => this.rewind());
-        // this.btnAddTrack?.addEventListener('click', () => this.addTrack());
-        // this.btnDropTrack?.addEventListener('click', () => this.dropTrack());
+        this.btnAddTrack?.addEventListener('click', () => this.addTrack());
+        this.btnDropTrack?.addEventListener('click', () => this.dropTrack());
         this.btnScen.addEventListener('click', () => this.setupRandomScenario());
 
         // Help Modal


### PR DESCRIPTION
## Summary
- include Add/Drop Track controls in track data header
- style buttons like radar CRT aesthetic
- hook buttons up to addTrack() / dropTrack() in arena.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865f1660ab48325bf732abf9f8a5b5e