### PR TITLE
Fix ownship vector drag to adjust ordered course

### DIFF
--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -1330,12 +1330,17 @@ class Simulator {
                 const dy = -(mouseY - startPoint.y);
 
                 const newCanvasAngleRad = Math.atan2(dy, dx);
-                let newCourse = this.canvasAngleToBearing(this.toDegrees(newCanvasAngleRad));
+                const newCourse = this.canvasAngleToBearing(this.toDegrees(newCanvasAngleRad));
                 const distOnCanvas = Math.sqrt(dx * dx + dy * dy);
                 const newSpeed = distOnCanvas / pixelsPerNm / timeInHours;
 
-                vessel.course = newCourse;
-                vessel.speed = Math.max((vessel.id === 'ownShip' ? 0 : 2), newSpeed);
+                if (vessel.id === 'ownShip') {
+                    vessel.orderedCourse = newCourse;
+                    vessel.orderedSpeed = Math.max(0, newSpeed);
+                } else {
+                    vessel.course = newCourse;
+                    vessel.speed = Math.max(2, newSpeed);
+                }
                 this.markSceneDirty();
             }
             this.lastMousePos = { x: mouseX, y: mouseY };


### PR DESCRIPTION
## Summary
- when dragging the ownship vector, update ordered course and speed instead of actual
- leave actual course/speed unchanged so the radar green vector shows current state while maneuvering

## Testing
- `node -c js/arena.js`

------
https://chatgpt.com/codex/tasks/task_e_6865fedcf5808325ad6be8cb0c3e3180