### PR TITLE
Enable touch drag for course/speed changes

### DIFF
--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -398,7 +398,13 @@ class Simulator {
             const wrap = (handler) => (e) => {
                 const touch = e.touches[0] || e.changedTouches[0];
                 if (!touch) return;
-                handler({ clientX: touch.clientX, clientY: touch.clientY, button: 0 });
+                handler({
+                    clientX: touch.clientX,
+                    clientY: touch.clientY,
+                    button: 0,
+                    buttons: 1,
+                    pointerType: 'touch'
+                });
                 e.preventDefault();
             };
             this.canvas.addEventListener('touchstart', wrap(this.handlePointerDown), { passive: false });


### PR DESCRIPTION
## Summary
- ensure touch drag events include button state

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68666b10c6cc832587c6e42165189291