### PR TITLE
Use numeric input for editing

### DIFF
--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -273,6 +273,7 @@ main {
     color: var(--radar-green);
     border: none;
     text-align: right;
+    cursor: text;
     font-size: inherit;
     font-family: inherit;
     width: 100%;

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -571,7 +571,7 @@ class Simulator {
         if (this.activeEditField === id) {
             if (this.suppressEditRender) return;
             if (!el.querySelector('input')) {
-                el.innerHTML = `<input type="text" value="${parseFloat(numericValue).toFixed(1)}">`;
+                el.innerHTML = `<input type="number" step="0.1" value="${parseFloat(numericValue).toFixed(1)}">`;
                 const input = el.querySelector('input');
                 const commit = () => {
                     const newVal = parseFloat(input.value);


### PR DESCRIPTION
## Summary
- use `<input type="number" step="0.1">` when editing values
- show text cursor while editing

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6866739351108325b5f7a8b9fdb7cbb2