### PR TITLE
Enable mobile number pad for editing

### DIFF
--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -571,7 +571,7 @@ class Simulator {
         if (this.activeEditField === id) {
             if (this.suppressEditRender) return;
             if (!el.querySelector('input')) {
-                el.innerHTML = `<input type="number" step="0.1" value="${parseFloat(numericValue).toFixed(1)}">`;
+                el.innerHTML = `<input type="number" step="0.1" inputmode="decimal" value="${parseFloat(numericValue).toFixed(1)}">`;
                 const input = el.querySelector('input');
                 const commit = () => {
                     const newVal = parseFloat(input.value);


### PR DESCRIPTION
## Summary
- show numeric keypad when editing course, speed, bearing and range values on touch devices by adding `inputmode="decimal"`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866d2f497d88325ab8d9ea247bfccd4