### PR TITLE
Add orange order vector tooltip

### DIFF
--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -76,6 +76,8 @@ body {
     --radar-white: #FFFFFF;
     --radar-faint-green: rgba(0, 255, 0, 0.5);
     --radar-faint-white: rgba(255, 255, 255, 0.5);
+    --radar-dark-orange: #FF8C00;
+    --radar-faint-orange: rgba(255, 140, 0, 0.5);
     /* fallback for dynamic 100vh calculation */
     --vh: 1vh;
     /* global UI scale set by JavaScript */
@@ -361,6 +363,19 @@ main {
     z-index: 1000;
     line-height: 1.4;
     white-space: pre; /* To respect newlines and spacing */
+}
+#order-tooltip {
+    position: fixed;
+    display: none;
+    background-color: rgba(0, 0, 0, 0.8);
+    color: var(--radar-dark-orange);
+    padding: 0.25rem 0.5rem;
+    font-size: 0.85rem;
+    border-radius: 0.25rem;
+    pointer-events: none;
+    z-index: 1000;
+    line-height: 1.4;
+    white-space: pre;
 }
 #logo, #logo span {
     font-family: 'Share Tech Mono', monospace;

--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -40,6 +40,7 @@
 <body>
 
 <div id="drag-tooltip"></div>
+<div id="order-tooltip"></div>
 
 <div id="mobile-blocker" class="mobile-blocker">
   Maneuver is currently not compatible with cell-phone browsers. <br> <br>

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -215,6 +215,7 @@ class Simulator {
         this.canvas = document.getElementById('radarCanvas');
         this.ctx = this.canvas.getContext('2d');
         this.dragTooltip = document.getElementById('drag-tooltip');
+        this.orderTooltip = document.getElementById('order-tooltip');
         // this.btnVectorTime = document.getElementById('btn-vector-time');
         // this.btnRmv = document.getElementById('btn-rmv');
         // this.btnCpa = document.getElementById('btn-cpa');
@@ -251,6 +252,7 @@ class Simulator {
         this.radarWhite = getComputedStyle(document.documentElement).getPropertyValue('--radar-white').trim();
         this.radarFaintGreen = getComputedStyle(document.documentElement).getPropertyValue('--radar-faint-green').trim();
         this.radarFaintWhite = getComputedStyle(document.documentElement).getPropertyValue('--radar-faint-white').trim();
+        this.radarDarkOrange = getComputedStyle(document.documentElement).getPropertyValue('--radar-dark-orange').trim();
         this.scenarioCfg = ScenarioConfig;
 
         // --- State Data ---
@@ -263,7 +265,8 @@ class Simulator {
             orderedCourse: 91,
             orderedSpeed: 12.7,
             dragCourse: null,
-            dragSpeed: null
+            dragSpeed: null,
+            orderedVectorEndpoint: null
         };
         this.tracks = [
             { id: '0001', initialBearing: 327, initialRange: 7.9, course: 255, speed: 6.1 },
@@ -905,14 +908,26 @@ class Simulator {
             const orderAngle = this.toRadians(this.bearingToCanvasAngle(orderedCourse));
             const oEndX = center + orderDistPixels * Math.cos(orderAngle);
             const oEndY = center - orderDistPixels * Math.sin(orderAngle);
+            this.ownShip.orderedVectorEndpoint = { x: oEndX, y: oEndY };
             this.ctx.save();
-            this.ctx.strokeStyle = this.radarFaintGreen;
+            this.ctx.strokeStyle = this.radarDarkOrange;
             this.ctx.lineWidth = 1.4 * 1.2 * 2;
             this.ctx.beginPath();
             this.ctx.moveTo(center, center);
             this.ctx.lineTo(oEndX, oEndY);
             this.ctx.stroke();
             this.ctx.restore();
+
+            const rect = this.canvas.getBoundingClientRect();
+            const tipX = rect.left + (oEndX / this.DPR);
+            const tipY = rect.top + (oEndY / this.DPR);
+            const txt = `Crs: ${orderedCourse.toFixed(1)} T\nSpd: ${orderedSpeed.toFixed(1)} kts`;
+            this.orderTooltip.innerText = txt;
+            this.orderTooltip.style.display = 'block';
+            this.orderTooltip.style.transform = `translate(${tipX - this.orderTooltip.offsetWidth - 10}px, ${tipY - this.orderTooltip.offsetHeight - 10}px)`;
+        } else {
+            this.orderTooltip.style.display = 'none';
+            this.ownShip.orderedVectorEndpoint = null;
         }
     }
 
@@ -1289,6 +1304,7 @@ class Simulator {
         this.pendingDragId = null;
         this.pendingDragType = null;
         this.dragTooltip.style.display = 'none';
+        this.orderTooltip.style.display = 'none';
         this.markSceneDirty();
     }
 


### PR DESCRIPTION
## Summary
- add new radar dark orange color
- style order-tooltip element
- insert order-tooltip in HTML
- load tooltip and color in JS simulator
- track ordered vector endpoint and show tooltip
- hide order-tooltip when finished or on pointer up

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866e2777d9483259a3d812b23c45a3e