### PR TITLE
Add fullscreen toggle button

### DIFF
--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -496,7 +496,24 @@ details[open] > summary.collapsible-summary::before {
     color: var(--radar-faint-green);
 }
 
+#btn-fullscreen {
+    position: absolute;
+    bottom: 40px;
+    left: 0;
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    color: var(--radar-faint-green);
+}
+
 #btn-settings:hover {
+    color: var(--radar-green);
+    cursor: pointer;
+}
+
+#btn-fullscreen:hover {
     color: var(--radar-green);
     cursor: pointer;
 }
@@ -506,7 +523,7 @@ details[open] > summary.collapsible-summary::before {
     position: fixed;
     left: 32px;
     bottom: 0;
-    width: 60px;
+    width: 90px;
     background: #000;
     border: 1px solid #333;
     border-bottom: none;

--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -235,6 +235,11 @@ Questions?  >>  Aheadflank.ai@gmail.com
                 <span>Beta</span>
             </section>
             <nav id="button-bar" class="d-flex flex-column align-items-bottom gap-2 justify-content-end"></nav>
+            <button id="btn-fullscreen">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M7 14H5v5h5v-2H7v-3zm0-4h2V7h3V5H7v5zm10 4h-2v3h-3v2h5v-5zm-2-4V7h-3V5h5v5h-2z"/>
+                </svg>
+            </button>
             <button id="btn-settings">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M19.14,12.94a7.14,7.14,0,0,0,0-1.88l2.11-1.65a.5.5,0,0,0,.12-.63l-2-3.46a.5.5,0,0,0-.6-.22l-2.49,1a7,7,0,0,0-1.62-.94l-.38-2.65A.5.5,0,0,0,13.7,3H10.3a.5.5,0,0,0-.49.41l-.38,2.65a7,7,0,0,0-1.62.94l-2.49-1a.5.5,0,0,0-.6.22l-2,3.46a.5.5,0,0,0,.12.63l2.11,1.65a7.14,7.14,0,0,0,0,1.88L3,14.59a.5.5,0,0,0-.12.63l2,3.46a.5.5,0,0,0,.6.22l2.49-1a7,7,0,0,0,1.62.94l.38,2.65a.5.5,0,0,0,.49.41h3.4a.5.5,0,0,0,.49-.41l.38-2.65a7,7,0,0,0,1.62-.94l2.49,1a.5.5,0,0,0,.6-.22l2-3.46a.5.5,0,0,0-.12-.63ZM12,15.5A3.5,3.5,0,1,1,15.5,12,3.5,3.5,0,0,1,12,15.5Z"/>

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -253,6 +253,7 @@ class Simulator {
         this.simClock = document.getElementById('sim-clock');
         this.mainContainer = document.querySelector('main.main-content');
         this.btnSettings = document.getElementById('btn-settings');
+        this.btnFullscreen = document.getElementById('btn-fullscreen');
         this.settingsDrawer = document.getElementById('settings-drawer');
         this.chkPolarPlot = document.getElementById('toggle-polar-plot');
         this.chkTrackIds = document.getElementById('toggle-track-ids');
@@ -496,6 +497,18 @@ class Simulator {
                 this.settingsDrawer.addEventListener('transitionend', () => {
                     this.settingsDrawer.style.display = 'none';
                 }, { once: true });
+            }
+        });
+        this.btnFullscreen.addEventListener('click', () => {
+            if (!document.fullscreenElement) {
+                document.documentElement.requestFullscreen();
+            } else {
+                document.exitFullscreen();
+            }
+        });
+        document.addEventListener('keydown', e => {
+            if (e.key === 'Escape' && document.fullscreenElement) {
+                document.exitFullscreen();
             }
         });
         this.chkPolarPlot.addEventListener('change', () => this.togglePolarPlot());


### PR DESCRIPTION
## Summary
- widen settings drawer
- add fullscreen button above settings button with hover styling
- implement fullscreen toggle logic

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68670657cf388325b7d93a98a1e93ae0