### PR TITLE
Add fullscreen toggle and widen settings drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,8 @@
 - Verified no performance regression: static grid recalculates only when dirty or canvas size changes.
 - Restored numeric range labels in faint green and removed cardinal direction labels.
 - Extended bearing lines beyond the outer ring for clearer reference.
+- Trimmed non-cardinal bearing lines within the polar plot and shortened their
+  outer segment by 20% while preserving cardinal line lengths.
+- Removed bearing line segments inside the outer range ring so all bearings now
+  originate at the ring itself.
 

--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -484,9 +484,11 @@ details[open] > summary.collapsible-summary::before {
 }
 
 /* Settings gear button */
+
+/* Full screen button */
+#btn-fullscreen,
 #btn-settings {
     position: fixed;
-    bottom: 15px;
     left: 32px;
     width: 30px;
     height: 30px;
@@ -497,7 +499,11 @@ details[open] > summary.collapsible-summary::before {
     z-index: 4;
 }
 
-#btn-settings:hover {
+#btn-fullscreen { bottom: 55px; }
+#btn-settings  { bottom: 15px; }
+
+#btn-settings:hover,
+#btn-fullscreen:hover {
     color: var(--radar-green);
     cursor: pointer;
 }
@@ -507,7 +513,7 @@ details[open] > summary.collapsible-summary::before {
     position: fixed;
     left: 32px;
     bottom: 15px;
-    width: 60px;
+    width: 120px;
     background: #000;
     border: 1px solid #333;
     border-bottom: none;

--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -235,6 +235,11 @@ Questions?  >>  Aheadflank.ai@gmail.com
                 <span>Beta</span>
             </section>
             <nav id="button-bar" class="d-flex flex-column align-items-bottom gap-2 justify-content-end"></nav>
+            <button id="btn-fullscreen">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M4 4h6v2H6v4H4V4m10 0h6v6h-2V6h-4V4m6 10v6h-6v-2h4v-4h2m-10 4h4v2H4v-6h2v4z"/>
+                </svg>
+            </button>
             <button id="btn-settings">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M19.14,12.94a7.14,7.14,0,0,0,0-1.88l2.11-1.65a.5.5,0,0,0,.12-.63l-2-3.46a.5.5,0,0,0-.6-.22l-2.49,1a7,7,0,0,0-1.62-.94l-.38-2.65A.5.5,0,0,0,13.7,3H10.3a.5.5,0,0,0-.49.41l-.38,2.65a7,7,0,0,0-1.62.94l-2.49-1a.5.5,0,0,0-.6.22l-2,3.46a.5.5,0,0,0,.12.63l2.11,1.65a7.14,7.14,0,0,0,0,1.88L3,14.59a.5.5,0,0,0-.12.63l2,3.46a.5.5,0,0,0,.6.22l2.49-1a7,7,0,0,0,1.62.94l.38,2.65a.5.5,0,0,0,.49.41h3.4a.5.5,0,0,0,.49-.41l.38-2.65a7,7,0,0,0,1.62-.94l2.49,1a.5.5,0,0,0,.6-.22l2-3.46a.5.5,0,0,0-.12-.63ZM12,15.5A3.5,3.5,0,1,1,15.5,12,3.5,3.5,0,0,1,12,15.5Z"/>

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -252,6 +252,7 @@ class Simulator {
         this.windDataContainer = document.getElementById('wind-data-container');
         this.simClock = document.getElementById('sim-clock');
         this.mainContainer = document.querySelector('main.main-content');
+        this.btnFullscreen = document.getElementById('btn-fullscreen');
         this.btnSettings = document.getElementById('btn-settings');
         this.settingsDrawer = document.getElementById('settings-drawer');
         this.chkPolarPlot = document.getElementById('toggle-polar-plot');
@@ -488,6 +489,13 @@ class Simulator {
             } else {
                 this.settingsDrawer.style.display = 'flex';
                 requestAnimationFrame(() => this.settingsDrawer.classList.add('open'));
+            }
+        });
+        // Fullscreen toggle
+        this.btnFullscreen.addEventListener('click', () => this.toggleFullScreen());
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && document.fullscreenElement) {
+                document.exitFullscreen();
             }
         });
         this.settingsDrawer.addEventListener('mouseleave', () => {
@@ -1618,6 +1626,14 @@ class Simulator {
     toggleTrackIds() {
         this.showTrackIds = !this.showTrackIds;
         this.markSceneDirty();
+    }
+
+    toggleFullScreen() {
+        if (!document.fullscreenElement) {
+            document.documentElement.requestFullscreen?.();
+        } else {
+            document.exitFullscreen?.();
+        }
     }
 
     setupRandomScenario(){

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -930,12 +930,20 @@ class Simulator {
                 const isCardinal = CARDINAL_BEARINGS.includes(deg);
                 ctx.setLineDash(isCardinal ? DASH_PATTERN_SOLID : DASH_PATTERN_NONCAR);
                 const ang = this.toRadians(deg);
-                const lineRadius = isCardinal ? (size / 2) : radius + (size / 2 - radius) / 2;
+                const originalRadius = isCardinal ? (size / 2) : radius + (size / 2 - radius) / 2;
+                const startRadius = radius;
+                let endRadius = originalRadius;
+                if (!isCardinal) {
+                    endRadius = radius + 0.8 * (originalRadius - radius);
+                }
                 ctx.beginPath();
-                ctx.moveTo(center, center);
+                ctx.moveTo(
+                    center + startRadius * Math.cos(ang),
+                    center - startRadius * Math.sin(ang)
+                );
                 ctx.lineTo(
-                    center + lineRadius * Math.cos(ang),
-                    center - lineRadius * Math.sin(ang)
+                    center + endRadius * Math.cos(ang),
+                    center - endRadius * Math.sin(ang)
                 );
                 ctx.stroke();
             }


### PR DESCRIPTION
## Summary
- make settings drawer wider
- add fullscreen button above settings
- implement JS fullscreen toggle and ESC exit handler

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686708420738832582376b6d40c50875