### PR TITLE
Update ownship drag visuals

### DIFF
--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -975,8 +975,8 @@ class Simulator {
         this.ctx.stroke();
 
         // Draw ordered course/speed vector if still manoeuvring
-        const orderedCourse = (this.ownShip.dragCourse !== null) ? this.ownShip.dragCourse : this.ownShip.orderedCourse;
-        const orderedSpeed  = (this.ownShip.dragSpeed  !== null) ? this.ownShip.dragSpeed  : this.ownShip.orderedSpeed;
+        const orderedCourse = this.ownShip.orderedCourse;
+        const orderedSpeed  = this.ownShip.orderedSpeed;
         const diffCourse = Math.abs(((orderedCourse - this.ownShip.course + 540) % 360) - 180);
         const diffSpeed  = Math.abs(orderedSpeed - this.ownShip.speed);
         if (diffCourse > 0.5 || diffSpeed > 0.05) {
@@ -985,9 +985,8 @@ class Simulator {
             const oEndX = center + orderDistPixels * Math.cos(orderAngle);
             const oEndY = center - orderDistPixels * Math.sin(orderAngle);
             this.ownShip.orderedVectorEndpoint = { x: oEndX, y: oEndY };
-            const dragging = this.draggedItemId === 'ownShip' && this.dragType === 'vector';
             this.ctx.save();
-            this.ctx.strokeStyle = dragging ? this.radarWhite : this.radarDarkOrange;
+            this.ctx.strokeStyle = this.radarDarkOrange;
             this.ctx.lineWidth = 1.4 * 1.2 * 2;
             this.ctx.beginPath();
             this.ctx.moveTo(center, center);
@@ -995,20 +994,33 @@ class Simulator {
             this.ctx.stroke();
             this.ctx.restore();
 
-            if (!dragging) {
-                const rect = this.canvas.getBoundingClientRect();
-                const tipX = rect.left + (oEndX / this.DPR);
-                const tipY = rect.top + (oEndY / this.DPR);
-                const txt = `Crs: ${orderedCourse.toFixed(1)} T\nSpd: ${orderedSpeed.toFixed(1)} kts`;
-                this.orderTooltip.innerText = txt;
-                this.orderTooltip.style.display = 'block';
-                this.orderTooltip.style.transform = `translate(${tipX - this.orderTooltip.offsetWidth - 10}px, ${tipY - this.orderTooltip.offsetHeight - 10}px)`;
-            } else {
-                this.orderTooltip.style.display = 'none';
-            }
+            const rect = this.canvas.getBoundingClientRect();
+            const tipX = rect.left + (oEndX / this.DPR);
+            const tipY = rect.top + (oEndY / this.DPR);
+            const txt = `Crs: ${orderedCourse.toFixed(1)} T\nSpd: ${orderedSpeed.toFixed(1)} kts`;
+            this.orderTooltip.style.color = this.radarDarkOrange;
+            this.orderTooltip.innerText = txt;
+            this.orderTooltip.style.display = 'block';
+            this.orderTooltip.style.transform = `translate(${tipX - this.orderTooltip.offsetWidth - 10}px, ${tipY - this.orderTooltip.offsetHeight - 10}px)`;
         } else {
             this.orderTooltip.style.display = 'none';
             this.ownShip.orderedVectorEndpoint = null;
+        }
+
+        const dragging = this.draggedItemId === 'ownShip' && this.dragType === 'vector';
+        if (dragging && this.ownShip.dragCourse !== null && this.ownShip.dragSpeed !== null) {
+            const dragDistPixels = this.ownShip.dragSpeed * timeInHours * pixelsPerNm;
+            const dragAngle = this.toRadians(this.bearingToCanvasAngle(this.ownShip.dragCourse));
+            const dEndX = center + dragDistPixels * Math.cos(dragAngle);
+            const dEndY = center - dragDistPixels * Math.sin(dragAngle);
+            this.ctx.save();
+            this.ctx.strokeStyle = this.radarWhite;
+            this.ctx.lineWidth = 1.4 * 1.2 * 2;
+            this.ctx.beginPath();
+            this.ctx.moveTo(center, center);
+            this.ctx.lineTo(dEndX, dEndY);
+            this.ctx.stroke();
+            this.ctx.restore();
         }
     }
 

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -513,6 +513,7 @@ class Simulator {
         document.querySelectorAll('[data-tooltip]').forEach(el => {
             el.addEventListener('pointerenter', e => {
                 this.dragTooltip.textContent = el.getAttribute('data-tooltip');
+                this.dragTooltip.style.color = this.radarGreen;
                 this.dragTooltip.style.display = 'block';
                 this.dragTooltip.style.transform = `translate(${e.clientX - this.dragTooltip.offsetWidth - 10}px, ${e.clientY - this.dragTooltip.offsetHeight - 10}px)`;
             });
@@ -984,8 +985,9 @@ class Simulator {
             const oEndX = center + orderDistPixels * Math.cos(orderAngle);
             const oEndY = center - orderDistPixels * Math.sin(orderAngle);
             this.ownShip.orderedVectorEndpoint = { x: oEndX, y: oEndY };
+            const dragging = this.draggedItemId === 'ownShip' && this.dragType === 'vector';
             this.ctx.save();
-            this.ctx.strokeStyle = this.radarDarkOrange;
+            this.ctx.strokeStyle = dragging ? this.radarWhite : this.radarDarkOrange;
             this.ctx.lineWidth = 1.4 * 1.2 * 2;
             this.ctx.beginPath();
             this.ctx.moveTo(center, center);
@@ -993,13 +995,17 @@ class Simulator {
             this.ctx.stroke();
             this.ctx.restore();
 
-            const rect = this.canvas.getBoundingClientRect();
-            const tipX = rect.left + (oEndX / this.DPR);
-            const tipY = rect.top + (oEndY / this.DPR);
-            const txt = `Crs: ${orderedCourse.toFixed(1)} T\nSpd: ${orderedSpeed.toFixed(1)} kts`;
-            this.orderTooltip.innerText = txt;
-            this.orderTooltip.style.display = 'block';
-            this.orderTooltip.style.transform = `translate(${tipX - this.orderTooltip.offsetWidth - 10}px, ${tipY - this.orderTooltip.offsetHeight - 10}px)`;
+            if (!dragging) {
+                const rect = this.canvas.getBoundingClientRect();
+                const tipX = rect.left + (oEndX / this.DPR);
+                const tipY = rect.top + (oEndY / this.DPR);
+                const txt = `Crs: ${orderedCourse.toFixed(1)} T\nSpd: ${orderedSpeed.toFixed(1)} kts`;
+                this.orderTooltip.innerText = txt;
+                this.orderTooltip.style.display = 'block';
+                this.orderTooltip.style.transform = `translate(${tipX - this.orderTooltip.offsetWidth - 10}px, ${tipY - this.orderTooltip.offsetHeight - 10}px)`;
+            } else {
+                this.orderTooltip.style.display = 'none';
+            }
         } else {
             this.orderTooltip.style.display = 'none';
             this.ownShip.orderedVectorEndpoint = null;
@@ -1334,6 +1340,11 @@ class Simulator {
         }
 
         if (tooltipText) {
+            if (this.draggedItemId === 'ownShip' && this.dragType === 'vector') {
+                this.dragTooltip.style.color = this.radarWhite;
+            } else {
+                this.dragTooltip.style.color = this.radarGreen;
+            }
             this.dragTooltip.innerText = tooltipText;
             this.dragTooltip.style.display = 'block';
             this.dragTooltip.style.transform = `translate(${e.clientX - this.dragTooltip.offsetWidth - 10}px, ${e.clientY - this.dragTooltip.offsetHeight - 10}px)`;


### PR DESCRIPTION
## Summary
- show green tooltip text by default
- color drag tooltip and vector white while dragging ownship
- hide order tooltip until drag is released

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686736c121cc83259085b1647501c67a