### PR TITLE
Improve fullscreen UX for mobile

### DIFF
--- a/Simulator/css/beta.css
+++ b/Simulator/css/beta.css
@@ -543,3 +543,20 @@ details[open] > summary.collapsible-summary::before {
 #settings-drawer input[type="checkbox"] {
     accent-color: var(--radar-green);
 }
+
+/* Prevent pull-to-refresh & rubber-band while allowing the OS escape swipe */
+html, body {
+  margin: 0;
+  height: 100%;
+  overscroll-behavior-x: contain;
+  overscroll-behavior-y: contain;
+}
+
+/* Canvas already has touch-action:none; declare shared draggable class too */
+.draggable, canvas {
+  touch-action: none;
+}
+
+/* Optional visual cue when in full-screen */
+:fullscreen #btn-fullscreen svg { transform: rotate(45deg); }
+:-webkit-full-screen #btn-fullscreen svg { transform: rotate(45deg); }

--- a/Simulator/index.html
+++ b/Simulator/index.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="manifest" href="manifest.json">
     <title>Maneuver: Simulator</title>
     <link rel="icon" type="image/svg+xml" href="favicons.svg">
     
@@ -235,7 +238,7 @@ Questions?  >>  Aheadflank.ai@gmail.com
                 <span>Beta</span>
             </section>
             <nav id="button-bar" class="d-flex flex-column align-items-bottom gap-2 justify-content-end"></nav>
-            <button id="btn-fullscreen">
+            <button id="btn-fullscreen" aria-label="Enter full screen" title="Enter full screen" data-state="enter">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M4 4h6v2H6v4H4V4m10 0h6v6h-2V6h-4V4m6 10v6h-6v-2h4v-4h2m-10 4h4v2H4v-6h2v4z"/>
                 </svg>

--- a/Simulator/js/arena.js
+++ b/Simulator/js/arena.js
@@ -211,6 +211,27 @@ class ContactController {
  * @class Simulator
  * Encapsulates the entire state and logic for the ship maneuvering simulator.
  */
+const fsApi = {
+  request(el = document.documentElement) {
+    return  el.requestFullscreen?.()     ||
+            el.webkitRequestFullscreen?.()||
+            el.mozRequestFullScreen?.()  ||
+            el.msRequestFullscreen?.();
+  },
+  exit() {
+    return  document.exitFullscreen?.()   ||
+            document.webkitExitFullscreen?.()||
+            document.mozCancelFullScreen?.() ||
+            document.msExitFullscreen?.();
+  },
+  isActive() {
+    return document.fullscreenElement     ||
+           document.webkitFullscreenElement||
+           document.mozFullScreenElement   ||
+           document.msFullscreenElement;
+  }
+};
+
 class Simulator {
     constructor() {
         // --- Suppress rendering flag for editable fields ---
@@ -344,6 +365,11 @@ class Simulator {
         this.handlePointerDown = this.handlePointerDown.bind(this);
         this.handlePointerUp = this.handlePointerUp.bind(this);
         this.handlePointerMove = this.handlePointerMove.bind(this);
+
+        // Update icon/text when FS changes
+        ['fullscreenchange','webkitfullscreenchange','mozfullscreenchange','MSFullscreenChange']
+          .forEach(evt => document.addEventListener(evt, () => this._syncFullscreenUI()));
+        this._syncFullscreenUI();   // set initial state
 
         this._initialize();
     }
@@ -494,8 +520,8 @@ class Simulator {
         // Fullscreen toggle
         this.btnFullscreen.addEventListener('click', () => this.toggleFullScreen());
         document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape' && document.fullscreenElement) {
-                document.exitFullscreen();
+            if (e.key === 'Escape' && fsApi.isActive()) {
+                fsApi.exit();
             }
         });
         this.settingsDrawer.addEventListener('mouseleave', () => {
@@ -1659,12 +1685,23 @@ class Simulator {
         this.markSceneDirty();
     }
 
-    toggleFullScreen() {
-        if (!document.fullscreenElement) {
-            document.documentElement.requestFullscreen?.();
-        } else {
-            document.exitFullscreen?.();
+    async toggleFullScreen() {
+        try {
+            if (!fsApi.isActive()) {
+                await fsApi.request();
+            } else {
+                await fsApi.exit();
+            }
+        } catch (err) {
+            console.error('Fullscreen error', err);
         }
+    }
+
+    _syncFullscreenUI() {
+        const entering = !!fsApi.isActive();
+        this.btnFullscreen.setAttribute('data-state', entering ? 'exit' : 'enter');
+        this.btnFullscreen.title     = entering ? 'Exit full screen' : 'Enter full screen';
+        this.btnFullscreen.ariaLabel = this.btnFullscreen.title;
     }
 
     setupRandomScenario(){

--- a/Simulator/manifest.json
+++ b/Simulator/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "Maneuver Radar Simulator",
+  "short_name": "Maneuver",
+  "display": "fullscreen",
+  "start_url": "./index.html",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    { "src": "icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add PWA meta tags and manifest link
- make fullscreen button accessible with aria attributes and data-state
- block pull-to-refresh gestures and support pointer dragging
- add cross-browser fullscreen helpers and sync UI on state changes
- include web app manifest

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68674acc0e8083258daa006c38df9a7f